### PR TITLE
fix: 非法文件名和XML字符

### DIFF
--- a/Export/HtmlExport.cs
+++ b/Export/HtmlExport.cs
@@ -13,6 +13,7 @@ using WechatBakTool.ViewModel;
 using System.Security.Policy;
 using System.Windows;
 using System.Xml.Linq;
+using WechatBakTool.Helpers;
 
 namespace WechatBakTool.Export
 {
@@ -144,7 +145,7 @@ namespace WechatBakTool.Export
                                 string xml = Encoding.UTF8.GetString(data);
                                 if (!string.IsNullOrEmpty(xml))
                                 {
-                                    xml = xml.Replace("\n", "");
+                                    xml = StringHelper.CleanInvalidXmlChars(xml);
                                     XmlDocument xmlObj = new XmlDocument();
                                     xmlObj.LoadXml(xml);
                                     if (xmlObj.DocumentElement != null)
@@ -211,7 +212,7 @@ namespace WechatBakTool.Export
                                 string xml = Encoding.UTF8.GetString(data);
                                 if (!string.IsNullOrEmpty(xml))
                                 {
-                                    xml = xml.Replace("\n", "");
+                                    xml = StringHelper.CleanInvalidXmlChars(xml);
                                     XmlDocument xmlObj = new XmlDocument();
                                     xmlObj.LoadXml(xml);
                                     if (xmlObj.DocumentElement != null)
@@ -263,7 +264,7 @@ namespace WechatBakTool.Export
                                 string xml = Encoding.UTF8.GetString(data);
                                 if (!string.IsNullOrEmpty(xml))
                                 {
-                                    xml = xml.Replace("\n", "");
+                                    xml = StringHelper.CleanInvalidXmlChars(xml);
                                     XmlDocument xmlObj = new XmlDocument();
                                     xmlObj.LoadXml(xml);
                                     if (xmlObj.DocumentElement != null)

--- a/Helpers/StringHelper.cs
+++ b/Helpers/StringHelper.cs
@@ -1,0 +1,46 @@
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace WechatBakTool.Helpers
+{
+  public static class StringHelper
+    {
+        /// <summary>
+        /// 清理XML中的非法字符
+        /// </summary>
+        /// <param name="input">需要清理的字符串</param>
+        /// <returns>清理后的字符串</returns>
+        public static string CleanInvalidXmlChars(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+                return input;
+
+            // #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
+            // 这里使用正则表达式匹配非法字符并替换
+            return Regex.Replace(input, @"[^\u0009\u000A\u000D\u0020-\uD7FF\uE000-\uFFFD]", "");
+        }
+
+        /// <summary>
+        /// 替换文件名中的非法字符为指定字符
+        /// </summary>
+        /// <param name="fileName">原始文件名</param>
+        /// <param name="replacement">用于替换非法字符的字符，默认为 "-"</param>
+        /// <returns>清理后的文件名</returns>
+        public static string SanitizeFileName(string fileName, char replacement = '-')
+        {
+            if (string.IsNullOrEmpty(fileName))
+                return fileName;
+
+            // 处理Windows系统中文件名不允许的特殊字符
+            char[] invalidFileNameChars = Path.GetInvalidFileNameChars();
+
+            foreach (char invalidChar in invalidFileNameChars)
+            {
+                fileName = fileName.Replace(invalidChar, '-');
+            }
+
+            return fileName;
+        }
+    }
+}

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/Pages/Manager.xaml.cs
+++ b/Pages/Manager.xaml.cs
@@ -20,6 +20,7 @@ using System.Windows.Navigation;
 using System.Xml;
 using WechatBakTool.Dialog;
 using WechatBakTool.Export;
+using WechatBakTool.Helpers;
 using WechatBakTool.Model;
 using WechatBakTool.ViewModel;
 
@@ -135,16 +136,14 @@ namespace WechatBakTool.Pages
         {
             workspaceViewModel.ExportCount = "";
             // string path = Path.Combine(Main2.CurrentUserBakConfig!.UserWorkspacePath, contact.UserName + ".html");
-            string name = contact.NickName;
-            name = name.Replace(@"\", "");
-            name = Regex.Replace(name, "[ \\[ \\] \\^ \\-_*×――(^)$%~!/@#$…&%￥—+=<>《》|!！??？:：•`·、。，；,.;\"‘’“”-]", "");
+            string fileName = StringHelper.SanitizeFileName(string.Format(
+                "{0}-{1}.html",
+                contact.UserName,
+                contact.Remark == "" ? contact.NickName : contact.Remark
+            ));
             string path = Path.Combine(
                 Main2.CurrentUserBakConfig!.UserWorkspacePath,
-                string.Format(
-                    "{0}-{1}.html",
-                    contact.UserName,
-                    contact.Remark == "" ? name : contact.Remark
-                )
+                fileName
             );
 
             IExport export = new HtmlExport();

--- a/Pages/Workspace.xaml.cs
+++ b/Pages/Workspace.xaml.cs
@@ -270,16 +270,14 @@ namespace WechatBakTool.Pages
                     return;
                 }
 
-                string name = ViewModel.WXContact.NickName;
-                name = name.Replace(@"\", "");
-                name = Regex.Replace(name, "[ \\[ \\] \\^ \\-_*×――(^)$%~!/@#$…&%￥—+=<>《》|!！??？:：•`·、。，；,.;\"‘’“”-]", "");
+                string fileName = StringHelper.SanitizeFileName(string.Format(
+                    "{0}-{1}",
+                    ViewModel.WXContact.UserName,
+                    ViewModel.WXContact.Remark == "" ? ViewModel.WXContact.NickName : ViewModel.WXContact.Remark
+                ));
                 string path = Path.Combine(
                     Main2.CurrentUserBakConfig!.UserWorkspacePath,
-                    string.Format(
-                        "{0}-{1}",
-                        ViewModel.WXContact.UserName,
-                        ViewModel.WXContact.Remark == "" ? name : ViewModel.WXContact.Remark
-                    )
+                    fileName
                 );
                 IExport export;
 


### PR DESCRIPTION
总有一些导出失败，目前查到两个原因。
- 日志记录显示xml非法字符，不止是0x08：
```cs
System.Xml.XmlException: '', hexadecimal value 0x08, is an invalid character. Line 1, position 61.
   at System.Xml.XmlTextReaderImpl.Throw(Exception e)
   at System.Xml.XmlTextReaderImpl.Throw(String res, String[] args)
   at System.Xml.XmlTextReaderImpl.ParseText(Int32& startPos, Int32& endPos, Int32& outOrChars)
   at System.Xml.XmlTextReaderImpl.ParseText()
   at System.Xml.XmlTextReaderImpl.ParseElementContent()
   at System.Xml.XmlTextReaderImpl.Read()
   at System.Xml.XmlLoader.LoadNode(Boolean skipOverWhitespace)
   at System.Xml.XmlLoader.LoadDocSequence(XmlDocument parentDoc)
   at System.Xml.XmlLoader.Load(XmlDocument doc, XmlReader reader, Boolean preserveWhitespace)
   at System.Xml.XmlDocument.Load(XmlReader reader)
   at System.Xml.XmlDocument.LoadXml(String xml)
```

- 导出文件的文件名也有非法字符，因为备注和昵称组成了文件名，也需要过滤。
- 另外，导出结束的时候按钮文字没恢复，一直都不知道是否结束